### PR TITLE
Add flag: CMAKE_INSTALL_PREFIX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,5 +3,5 @@ project(cutefish-icons)
 
 include(FeatureSummary)
 
-install(DIRECTORY Crule DESTINATION /usr/share/icons)
-install(DIRECTORY Crule-dark DESTINATION /usr/share/icons) 
+install(DIRECTORY Crule DESTINATION ${CMAKE_INSTALL_PREFIX}/usr/share/icons)
+install(DIRECTORY Crule-dark DESTINATION ${CMAKE_INSTALL_PREFIX}/usr/share/icons) 


### PR DESCRIPTION
Define the installation path by specifying the value of CMAKE_INSTALL_PREFIX.

For example:

      mkdir build
      cd build
      cmake ../ -DCMAKE_INSTALL_PREFIX=/home/xxx/xxx
      make install

Finally these files will be installed in '/home/xxx/xxx', 
This is useful for some developers or packagers.