### PR TITLE
Fix: brave-desktop icon from aur 

### DIFF
--- a/Crule/apps/scalable/brave-desktop.svg
+++ b/Crule/apps/scalable/brave-desktop.svg
@@ -1,0 +1,1 @@
+brave.svg


### PR DESCRIPTION
Fix brave icon from aur, because Icon Name of Brave Browser on Desktop Entry is `brave-desktop`.

![image](https://user-images.githubusercontent.com/18456011/140607632-8d92c9a6-60e7-4c7e-ad10-51d88f929c16.png)

This AUR Link :  
https://aur.archlinux.org/packages/brave-bin